### PR TITLE
Fix: Correct path to loginStyle.css in login.html

### DIFF
--- a/login.html
+++ b/login.html
@@ -6,7 +6,7 @@
     <link rel="icon" href="imgs/logo.png" type="image/png">
     <title>OneTech | Login</title>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="css/loginStyle.css">
+    <link rel="stylesheet" href="CSS/loginStyle.css">
     <link rel="stylesheet" href="CSS/home-style.css">
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="JS/login.js"></script>


### PR DESCRIPTION
The login page was not displaying correctly because the path to the CSS file `loginStyle.css` was incorrect. The path used `css/loginStyle.css` (lowercase "css") while the actual directory is named `CSS` (uppercase "CSS").

This commit corrects the href attribute in the link tag in `login.html` to use the correct case: `CSS/loginStyle.css`.